### PR TITLE
feat: extend lexer to handle fn statements

### DIFF
--- a/.changeset/extended_the_lexer_to_tokenize_fn.md
+++ b/.changeset/extended_the_lexer_to_tokenize_fn.md
@@ -1,0 +1,5 @@
+---
+default: minor
+---
+
+# extended the lexer to tokenize `fn`

--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -19,6 +19,7 @@ impl Lexer<'_> {
 
     pub fn next(&mut self) -> Token {
         // NOTE: order of quantifiers is important.
+        // NOTE: direct usage of quantifiers and not using dynamic dispatch is for performance.
         if let Some(_) = self.chars.peek() {
             if let Some(token) = WhitespaceQuantifier::process(&mut self.chars) {
                 return token;
@@ -99,6 +100,45 @@ mod tests {
             Token::IDENT("five".into()),
             Token::ASSIGN,
             Token::INT("5".into()),
+            Token::SEMICOLON,
+            Token::EOF,
+        ];
+
+        let mut lexer = Lexer::new(input);
+
+        for expected in tokens {
+            let actual = lexer.next();
+            assert_eq!(actual, expected);
+        }
+    }
+
+    #[test]
+    fn test_function_statement() {
+        let input = "let add = fn(x, y) { x + y; }; add(5, 10);";
+
+        let tokens = vec![
+            Token::LET,
+            Token::IDENT("add".into()),
+            Token::ASSIGN,
+            Token::FUNCTION,
+            Token::LPAREN,
+            Token::IDENT("x".into()),
+            Token::COMMA,
+            Token::IDENT("y".into()),
+            Token::RPAREN,
+            Token::LBRACE,
+            Token::IDENT("x".into()),
+            Token::PLUS,
+            Token::IDENT("y".into()),
+            Token::SEMICOLON,
+            Token::RBRACE,
+            Token::SEMICOLON,
+            Token::IDENT("add".into()),
+            Token::LPAREN,
+            Token::INT("5".into()),
+            Token::COMMA,
+            Token::INT("10".into()),
+            Token::RPAREN,
             Token::SEMICOLON,
             Token::EOF,
         ];

--- a/src/lexer/quantifiers.rs
+++ b/src/lexer/quantifiers.rs
@@ -94,6 +94,7 @@ impl Quantifier for KeywordAndIdentifiersQuantifier {
     fn process(chars: &mut Peekable<Chars>) -> Option<Token> {
         match utils::take_series_where(chars, |c| c.is_ascii_alphanumeric() || *c == '_') {
             Some(keyword) => match &keyword[..] {
+                "fn" => Some(Token::FUNCTION),
                 "let" => Some(Token::LET),
                 identifier => Some(Token::IDENT(Box::from(identifier))),
             },

--- a/src/lexer/tokens.rs
+++ b/src/lexer/tokens.rs
@@ -24,5 +24,6 @@ pub enum Token {
 
     // keywords & identifiers
     LET,
+    FUNCTION,
     IDENT(Box<str>),
 }


### PR DESCRIPTION
## 🎯 Changes

extended the lexer to handle function statements

i.e `let add = fn(x, y) { x + y; };`