### PR TITLE
refactor: split mutable and immutable spans into different structs

### DIFF
--- a/src/lexer/mod.rs
+++ b/src/lexer/mod.rs
@@ -11,14 +11,14 @@ use std::{iter::Peekable, str::Chars};
 
 pub struct Lexer<'a> {
     chars: Peekable<Chars<'a>>,
-    span: Span,
+    span: FramedSpan,
 }
 
 impl Lexer<'_> {
     pub fn new<'a>(input: &'a str) -> Lexer<'a> {
         Lexer {
             chars: input.trim().chars().peekable(),
-            span: Span::new(),
+            span: FramedSpan::new(),
         }
     }
 
@@ -53,7 +53,7 @@ impl Lexer<'_> {
             }
 
             return Token::ILLEGAL {
-                span: self.span.clone(),
+                span: self.span.capture(),
             };
         }
 
@@ -82,58 +82,58 @@ mod tests {
 
         let tokens = vec![
             Token::ASSIGN {
-                span: Span::from(1, 1, 1),
+                span: Span::new(1, 1, 1),
             },
             Token::PLUS {
-                span: Span::from(1, 3, 1),
+                span: Span::new(1, 3, 1),
             },
             Token::LPAREN {
-                span: Span::from(1, 5, 1),
+                span: Span::new(1, 5, 1),
             },
             Token::RPAREN {
-                span: Span::from(1, 7, 1),
+                span: Span::new(1, 7, 1),
             },
             Token::LBRACE {
-                span: Span::from(1, 9, 1),
+                span: Span::new(1, 9, 1),
             },
             Token::RBRACE {
-                span: Span::from(1, 11, 1),
+                span: Span::new(1, 11, 1),
             },
             Token::COMMA {
-                span: Span::from(1, 13, 1),
+                span: Span::new(1, 13, 1),
             },
             Token::SEMICOLON {
-                span: Span::from(1, 15, 1),
+                span: Span::new(1, 15, 1),
             },
             Token::BANG {
-                span: Span::from(1, 17, 1),
+                span: Span::new(1, 17, 1),
             },
             Token::MINUS {
-                span: Span::from(1, 19, 1),
+                span: Span::new(1, 19, 1),
             },
             Token::SLASH {
-                span: Span::from(1, 21, 1),
+                span: Span::new(1, 21, 1),
             },
             Token::ASTERISK {
-                span: Span::from(1, 23, 1),
+                span: Span::new(1, 23, 1),
             },
             Token::LT {
-                span: Span::from(1, 25, 1),
+                span: Span::new(1, 25, 1),
             },
             Token::GT {
-                span: Span::from(1, 27, 1),
+                span: Span::new(1, 27, 1),
             },
             Token::EQ {
-                span: Span::from(1, 29, 2),
+                span: Span::new(1, 29, 2),
             },
             Token::NEQ {
-                span: Span::from(1, 32, 2),
+                span: Span::new(1, 32, 2),
             },
             Token::LTE {
-                span: Span::from(1, 35, 2),
+                span: Span::new(1, 35, 2),
             },
             Token::GTE {
-                span: Span::from(1, 38, 2),
+                span: Span::new(1, 38, 2),
             },
             Token::EOF,
         ];
@@ -152,21 +152,21 @@ mod tests {
 
         let tokens = vec![
             Token::LET {
-                span: Span::from(1, 1, 3),
+                span: Span::new(1, 1, 3),
             },
             Token::IDENT {
-                span: Span::from(1, 5, 4),
+                span: Span::new(1, 5, 4),
                 value: "five".into(),
             },
             Token::ASSIGN {
-                span: Span::from(1, 10, 1),
+                span: Span::new(1, 10, 1),
             },
             Token::INT {
-                span: Span::from(1, 12, 1),
+                span: Span::new(1, 12, 1),
                 value: "5".into(),
             },
             Token::SEMICOLON {
-                span: Span::from(1, 13, 1),
+                span: Span::new(1, 13, 1),
             },
             Token::EOF,
         ];
@@ -185,81 +185,81 @@ mod tests {
 
         let tokens = vec![
             Token::LET {
-                span: Span::from(1, 1, 3),
+                span: Span::new(1, 1, 3),
             },
             Token::IDENT {
-                span: Span::from(1, 5, 3),
+                span: Span::new(1, 5, 3),
                 value: "add".into(),
             },
             Token::ASSIGN {
-                span: Span::from(1, 9, 1),
+                span: Span::new(1, 9, 1),
             },
             Token::FUNCTION {
-                span: Span::from(1, 11, 2),
+                span: Span::new(1, 11, 2),
             },
             Token::LPAREN {
-                span: Span::from(1, 13, 1),
+                span: Span::new(1, 13, 1),
             },
             Token::IDENT {
-                span: Span::from(1, 14, 1),
+                span: Span::new(1, 14, 1),
                 value: "x".into(),
             },
             Token::COMMA {
-                span: Span::from(1, 15, 1),
+                span: Span::new(1, 15, 1),
             },
             Token::IDENT {
-                span: Span::from(1, 17, 1),
+                span: Span::new(1, 17, 1),
                 value: "y".into(),
             },
             Token::RPAREN {
-                span: Span::from(1, 18, 1),
+                span: Span::new(1, 18, 1),
             },
             Token::LBRACE {
-                span: Span::from(1, 20, 1),
+                span: Span::new(1, 20, 1),
             },
             Token::IDENT {
-                span: Span::from(1, 22, 1),
+                span: Span::new(1, 22, 1),
                 value: "x".into(),
             },
             Token::PLUS {
-                span: Span::from(1, 24, 1),
+                span: Span::new(1, 24, 1),
             },
             Token::IDENT {
-                span: Span::from(1, 26, 1),
+                span: Span::new(1, 26, 1),
                 value: "y".into(),
             },
             Token::SEMICOLON {
-                span: Span::from(1, 27, 1),
+                span: Span::new(1, 27, 1),
             },
             Token::RBRACE {
-                span: Span::from(1, 29, 1),
+                span: Span::new(1, 29, 1),
             },
             Token::SEMICOLON {
-                span: Span::from(1, 30, 1),
+                span: Span::new(1, 30, 1),
             },
             Token::IDENT {
-                span: Span::from(2, 1, 3),
+                span: Span::new(2, 1, 3),
                 value: "add".into(),
             },
             Token::LPAREN {
-                span: Span::from(2, 4, 1),
+                span: Span::new(2, 4, 1),
             },
             Token::INT {
-                span: Span::from(2, 5, 1),
+                span: Span::new(2, 5, 1),
                 value: "5".into(),
             },
             Token::COMMA {
-                span: Span::from(2, 6, 1),
+                span: Span::new(2, 6, 1),
             },
             Token::INT {
-                span: Span::from(2, 8, 2),
+                span: Span::new(2, 8, 2),
                 value: "10".into(),
             },
             Token::RPAREN {
-                span: Span::from(2, 10, 1),
+                span: Span::new(2, 10, 1),
             },
             Token::SEMICOLON {
-                span: Span::from(2, 11, 1),
+                span: Span::new(2, 11, 1),
             },
             Token::EOF,
         ];
@@ -278,57 +278,57 @@ mod tests {
 
         let tokens = vec![
             Token::IF {
-                span: Span::from(1, 1, 2),
+                span: Span::new(1, 1, 2),
             },
             Token::LPAREN {
-                span: Span::from(1, 4, 1),
+                span: Span::new(1, 4, 1),
             },
             Token::INT {
-                span: Span::from(1, 5, 1),
+                span: Span::new(1, 5, 1),
                 value: "5".into(),
             },
             Token::LT {
-                span: Span::from(1, 7, 1),
+                span: Span::new(1, 7, 1),
             },
             Token::INT {
-                span: Span::from(1, 9, 2),
+                span: Span::new(1, 9, 2),
                 value: "10".into(),
             },
             Token::RPAREN {
-                span: Span::from(1, 11, 1),
+                span: Span::new(1, 11, 1),
             },
             Token::LBRACE {
-                span: Span::from(1, 13, 1),
+                span: Span::new(1, 13, 1),
             },
             Token::RETURN {
-                span: Span::from(1, 15, 6),
+                span: Span::new(1, 15, 6),
             },
             Token::TRUE {
-                span: Span::from(1, 22, 4),
+                span: Span::new(1, 22, 4),
             },
             Token::SEMICOLON {
-                span: Span::from(1, 26, 1),
+                span: Span::new(1, 26, 1),
             },
             Token::RBRACE {
-                span: Span::from(1, 28, 1),
+                span: Span::new(1, 28, 1),
             },
             Token::ELSE {
-                span: Span::from(1, 30, 4),
+                span: Span::new(1, 30, 4),
             },
             Token::LBRACE {
-                span: Span::from(1, 35, 1),
+                span: Span::new(1, 35, 1),
             },
             Token::RETURN {
-                span: Span::from(1, 37, 6),
+                span: Span::new(1, 37, 6),
             },
             Token::FALSE {
-                span: Span::from(1, 44, 5),
+                span: Span::new(1, 44, 5),
             },
             Token::SEMICOLON {
-                span: Span::from(1, 49, 1),
+                span: Span::new(1, 49, 1),
             },
             Token::RBRACE {
-                span: Span::from(1, 51, 1),
+                span: Span::new(1, 51, 1),
             },
         ];
 

--- a/src/lexer/quantifiers.rs
+++ b/src/lexer/quantifiers.rs
@@ -1,14 +1,14 @@
-use super::{utils, Span, Token};
+use super::{utils, FramedSpan, Token};
 use std::{iter::Peekable, str::Chars};
 
 pub trait Quantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token>;
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token>;
 }
 
 pub struct WhitespaceQuantifier;
 
 impl Quantifier for WhitespaceQuantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token> {
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token> {
         if let Some(whitespace) = utils::take_series_where(chars, |c| c.is_whitespace()) {
             span.advance(&whitespace);
         }
@@ -20,7 +20,7 @@ impl Quantifier for WhitespaceQuantifier {
 pub struct OperatorsQuantifier;
 
 impl Quantifier for OperatorsQuantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token> {
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token> {
         match chars.peek()? {
             '=' => {
                 chars.next();
@@ -28,33 +28,45 @@ impl Quantifier for OperatorsQuantifier {
                     Some('=') => {
                         chars.next();
                         span.advance("==");
-                        Some(Token::EQ { span: span.clone() })
+                        Some(Token::EQ {
+                            span: span.capture(),
+                        })
                     }
                     _ => {
                         span.advance("=");
-                        Some(Token::ASSIGN { span: span.clone() })
+                        Some(Token::ASSIGN {
+                            span: span.capture(),
+                        })
                     }
                 }
             }
             '+' => {
                 chars.next();
                 span.advance("+");
-                Some(Token::PLUS { span: span.clone() })
+                Some(Token::PLUS {
+                    span: span.capture(),
+                })
             }
             '-' => {
                 chars.next();
                 span.advance("-");
-                Some(Token::MINUS { span: span.clone() })
+                Some(Token::MINUS {
+                    span: span.capture(),
+                })
             }
             '*' => {
                 chars.next();
                 span.advance("*");
-                Some(Token::ASTERISK { span: span.clone() })
+                Some(Token::ASTERISK {
+                    span: span.capture(),
+                })
             }
             '/' => {
                 chars.next();
                 span.advance("/");
-                Some(Token::SLASH { span: span.clone() })
+                Some(Token::SLASH {
+                    span: span.capture(),
+                })
             }
             '!' => {
                 chars.next();
@@ -62,11 +74,15 @@ impl Quantifier for OperatorsQuantifier {
                     Some('=') => {
                         chars.next();
                         span.advance("!=");
-                        Some(Token::NEQ { span: span.clone() })
+                        Some(Token::NEQ {
+                            span: span.capture(),
+                        })
                     }
                     _ => {
                         span.advance("!");
-                        Some(Token::BANG { span: span.clone() })
+                        Some(Token::BANG {
+                            span: span.capture(),
+                        })
                     }
                 }
             }
@@ -76,11 +92,15 @@ impl Quantifier for OperatorsQuantifier {
                     Some('=') => {
                         chars.next();
                         span.advance("<=");
-                        Some(Token::LTE { span: span.clone() })
+                        Some(Token::LTE {
+                            span: span.capture(),
+                        })
                     }
                     _ => {
                         span.advance("<");
-                        Some(Token::LT { span: span.clone() })
+                        Some(Token::LT {
+                            span: span.capture(),
+                        })
                     }
                 }
             }
@@ -90,11 +110,15 @@ impl Quantifier for OperatorsQuantifier {
                     Some('=') => {
                         chars.next();
                         span.advance(">=");
-                        Some(Token::GTE { span: span.clone() })
+                        Some(Token::GTE {
+                            span: span.capture(),
+                        })
                     }
                     _ => {
                         span.advance(">");
-                        Some(Token::GT { span: span.clone() })
+                        Some(Token::GT {
+                            span: span.capture(),
+                        })
                     }
                 }
             }
@@ -106,17 +130,21 @@ impl Quantifier for OperatorsQuantifier {
 pub struct DelimitersQuantifier;
 
 impl Quantifier for DelimitersQuantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token> {
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token> {
         match chars.peek()? {
             ',' => {
                 chars.next();
                 span.advance(",");
-                Some(Token::COMMA { span: span.clone() })
+                Some(Token::COMMA {
+                    span: span.capture(),
+                })
             }
             ';' => {
                 chars.next();
                 span.advance(";");
-                Some(Token::SEMICOLON { span: span.clone() })
+                Some(Token::SEMICOLON {
+                    span: span.capture(),
+                })
             }
             _ => None,
         }
@@ -126,27 +154,35 @@ impl Quantifier for DelimitersQuantifier {
 pub struct BracketsQuantifier;
 
 impl Quantifier for BracketsQuantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token> {
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token> {
         match chars.peek()? {
             '(' => {
                 chars.next();
                 span.advance("(");
-                Some(Token::LPAREN { span: span.clone() })
+                Some(Token::LPAREN {
+                    span: span.capture(),
+                })
             }
             ')' => {
                 chars.next();
                 span.advance(")");
-                Some(Token::RPAREN { span: span.clone() })
+                Some(Token::RPAREN {
+                    span: span.capture(),
+                })
             }
             '{' => {
                 chars.next();
                 span.advance("{");
-                Some(Token::LBRACE { span: span.clone() })
+                Some(Token::LBRACE {
+                    span: span.capture(),
+                })
             }
             '}' => {
                 chars.next();
                 span.advance("}");
-                Some(Token::RBRACE { span: span.clone() })
+                Some(Token::RBRACE {
+                    span: span.capture(),
+                })
             }
             _ => None,
         }
@@ -156,13 +192,13 @@ impl Quantifier for BracketsQuantifier {
 pub struct LiteralsQuantifier;
 
 impl Quantifier for LiteralsQuantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token> {
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token> {
         match utils::take_series_where(chars, |c| c.is_ascii_digit()) {
             Some(literal) => {
                 span.advance(&literal);
 
                 Some(Token::INT {
-                    span: span.clone(),
+                    span: span.capture(),
                     value: Box::from(literal),
                 })
             }
@@ -174,21 +210,35 @@ impl Quantifier for LiteralsQuantifier {
 pub struct KeywordAndIdentifiersQuantifier;
 
 impl Quantifier for KeywordAndIdentifiersQuantifier {
-    fn process(chars: &mut Peekable<Chars>, span: &mut Span) -> Option<Token> {
+    fn process(chars: &mut Peekable<Chars>, span: &mut FramedSpan) -> Option<Token> {
         match utils::take_series_where(chars, |c| c.is_ascii_alphanumeric() || *c == '_') {
             Some(keyword) => {
                 span.advance(&keyword);
 
                 match &keyword[..] {
-                    "let" => Some(Token::LET { span: span.clone() }),
-                    "fn" => Some(Token::FUNCTION { span: span.clone() }),
-                    "return" => Some(Token::RETURN { span: span.clone() }),
-                    "if" => Some(Token::IF { span: span.clone() }),
-                    "else" => Some(Token::ELSE { span: span.clone() }),
-                    "true" => Some(Token::TRUE { span: span.clone() }),
-                    "false" => Some(Token::FALSE { span: span.clone() }),
+                    "let" => Some(Token::LET {
+                        span: span.capture(),
+                    }),
+                    "fn" => Some(Token::FUNCTION {
+                        span: span.capture(),
+                    }),
+                    "return" => Some(Token::RETURN {
+                        span: span.capture(),
+                    }),
+                    "if" => Some(Token::IF {
+                        span: span.capture(),
+                    }),
+                    "else" => Some(Token::ELSE {
+                        span: span.capture(),
+                    }),
+                    "true" => Some(Token::TRUE {
+                        span: span.capture(),
+                    }),
+                    "false" => Some(Token::FALSE {
+                        span: span.capture(),
+                    }),
                     identifier => Some(Token::IDENT {
-                        span: span.clone(),
+                        span: span.capture(),
                         value: Box::from(identifier),
                     }),
                 }

--- a/src/lexer/span.rs
+++ b/src/lexer/span.rs
@@ -1,24 +1,16 @@
 #[derive(Debug, PartialEq, Clone)]
 pub struct Span {
     line: usize,
-    column_start: usize,
-    column_end: usize,
+    column: usize,
+    length: usize,
 }
 
 impl Span {
-    pub fn new() -> Self {
-        Self {
-            line: 1,
-            column_start: 0,
-            column_end: 0,
-        }
-    }
-
-    pub fn from(line: usize, column: usize, length: usize) -> Self {
+    pub fn new(line: usize, column: usize, length: usize) -> Self {
         Self {
             line,
-            column_start: column,
-            column_end: column + length - 1,
+            column,
+            length,
         }
     }
 
@@ -27,16 +19,27 @@ impl Span {
     }
 
     pub fn column(&self) -> usize {
-        match self.column_start {
-            0 => 1,
-            _ => self.column_start,
-        }
+        self.column
     }
 
     pub fn length(&self) -> usize {
-        match self.column_end >= self.column_start {
-            true => self.column_end - self.column_start + 1,
-            false => 0,
+        self.length
+    }
+}
+
+#[derive(Debug)]
+pub struct FramedSpan {
+    line: usize,
+    column_start: usize,
+    column_end: usize,
+}
+
+impl FramedSpan {
+    pub fn new() -> Self {
+        Self {
+            line: 1,
+            column_start: 0,
+            column_end: 0,
         }
     }
 
@@ -59,5 +62,21 @@ impl Span {
                 }
             }
         }
+    }
+
+    pub fn capture(&self) -> Span {
+        let line = self.line;
+
+        let column = match self.column_start {
+            0 => 1,
+            _ => self.column_start,
+        };
+
+        let length = match self.column_end >= self.column_start {
+            true => self.column_end - self.column_start + 1,
+            false => 0,
+        };
+
+        Span::new(line, column, length)
     }
 }


### PR DESCRIPTION
## 🎯 Changes

created `FramedSpan` struct that advances on literils then can be captured into immutable `Span` struct that will be stored into tokens.