### PR TITLE
refactor: implement cursor for lexer

### DIFF
--- a/src/lexer/cursor.rs
+++ b/src/lexer/cursor.rs
@@ -1,0 +1,49 @@
+use std::str::Chars;
+
+#[derive(Debug, Clone)]
+pub struct Cursor<'a> {
+    chars: Chars<'a>,
+    current: Option<char>,
+    next: Option<char>,
+    exhausted: bool,
+}
+
+impl<'a> Cursor<'a> {
+    pub fn new(input: &'a str) -> Self {
+        let mut cursor = Self {
+            chars: input.chars(),
+            current: None,
+            next: None,
+            exhausted: false,
+        };
+
+        cursor.advance();
+
+        cursor
+    }
+
+    pub fn advance(&mut self) {
+        if self.exhausted {
+            return;
+        }
+
+        self.current = match self.next.take() {
+            Some(c) => Some(c),
+            None => self.chars.next(),
+        };
+
+        self.next = self.chars.next();
+
+        if self.current.is_none() {
+            self.exhausted = true;
+        }
+    }
+
+    pub const fn current(&self) -> Option<char> {
+        self.current
+    }
+
+    pub fn next(&self) -> Option<char> {
+        self.next
+    }
+}

--- a/src/lexer/utils.rs
+++ b/src/lexer/utils.rs
@@ -1,5 +1,5 @@
+use super::Cursor;
 use crate::TokenSpan;
-use std::{iter::Peekable, str::Chars};
 
 #[derive(Debug)]
 pub struct SpanTracker {
@@ -59,17 +59,17 @@ impl SpanTracker {
     }
 }
 
-pub fn take_series_where<F>(chars: &mut Peekable<Chars>, predicate: F) -> Option<Box<str>>
+pub fn take_series_where<F>(cursor: &mut Cursor, predicate: F) -> Option<Box<str>>
 where
     F: Fn(&char) -> bool,
 {
     let mut result = String::new();
 
-    while let Some(c) = chars.peek() {
-        match predicate(c) {
+    while let Some(c) = cursor.current() {
+        match predicate(&c) {
             true => {
-                result.push(*c);
-                chars.next();
+                result.push(c);
+                cursor.advance();
             }
             false => break,
         }


### PR DESCRIPTION
## 🎯 Changes

- Introduced a new `Cursor` struct in `src/lexer/cursor.rs` to manage input traversal
- Updated `Lexer` to use `Cursor` instead of `Peekable<Chars>`
- Refactored all lexer rules to work with the new `Cursor` struct
- Modified `take_series_where` function to use `Cursor` instead of `Peekable<Chars>`
- Updated unit tests to use `Cursor` for input handling

This refactoring improves the lexer's input handling by providing a more robust and flexible way to traverse the input string. The `Cursor` struct allows for easier peeking and advancing through the input, which simplifies the implementation of lexer rules and improves overall code readability.