### PR TITLE
feat: use single prefix for error messages

### DIFF
--- a/src/error.rs
+++ b/src/error.rs
@@ -1,8 +1,8 @@
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
-    #[error("parse error: {0}")]
+    #[error(transparent)]
     Parser(#[from] crate::parser::error::Error),
-    #[error("evaluation error: {0}")]
+    #[error(transparent)]
     Evaluator(#[from] crate::evaluator::error::Error),
 }
 


### PR DESCRIPTION
## 🎯 Changes

- Updated error handling in the `Error` enum to use `#[error(transparent)]`
- Removed explicit error message prefixes for `Parser` and `Evaluator` variants
- Simplified error propagation by relying on the underlying error types

These changes improve error handling by allowing the original error messages to be displayed without additional prefixes, resulting in cleaner and more direct error reporting.