### PR TITLE
refactor(parser): simplify rule parsing logic

### DIFF
--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -40,7 +40,7 @@ pub struct ExpressionParser;
 impl ExpressionParser {
     fn parse_left(lexer: &mut Lexer) -> Result<Expression> {
         for rule in &EXPRESSION_RULES {
-            if let Some(expression) = Rule::parse(&None, rule, lexer)? {
+            if let Some(expression) = rule.parse(lexer, None)? {
                 return Ok(expression);
             }
         }
@@ -91,266 +91,133 @@ const EXPRESSION_RULES: [Rule<Expression>; 9] = [
 ];
 
 const GROUPING_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::LPAREN,
-    parse: |lexer, _| {
-        match lexer.next() {
-            Some(token) if token.kind == TokenKind::LPAREN => token,
-            option => return Err(Error::MissingOpeningParenthesis(option)),
-        };
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::LPAREN {
+                return Ok(None);
+            }
 
-        let expression = ExpressionParser::parse(lexer, &Precedence::LOWEST)?;
+            match lexer.next() {
+                Some(token) if token.kind == TokenKind::LPAREN => token,
+                option => return Err(Error::MissingOpeningParenthesis(option)),
+            };
 
-        match lexer.next() {
-            Some(token) if token.kind == TokenKind::RPAREN => token,
-            option => return Err(Error::MissingClosingParenthesis(option)),
-        };
+            let expression = ExpressionParser::parse(lexer, &Precedence::LOWEST)?;
 
-        Ok(expression)
+            match lexer.next() {
+                Some(token) if token.kind == TokenKind::RPAREN => token,
+                option => return Err(Error::MissingClosingParenthesis(option)),
+            };
+
+            return Ok(Some(expression));
+        }
+
+        Ok(None)
     },
     dependents: None,
 };
 
 const IDENTIFIER_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::IDENT,
-    parse: |lexer, _| {
-        let token = lexer.next().unwrap();
-        let value = token.literal.clone();
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::IDENT {
+                return Ok(None);
+            }
 
-        Ok(Expression::IDENT(IdentExpression { token, value }))
+            let token = lexer.next().unwrap();
+            let value = token.literal.clone();
+
+            return Ok(Some(Expression::IDENT(IdentExpression { token, value })));
+        }
+
+        Ok(None)
     },
     dependents: Some(&[CALL_EXPRESSION_RULE, INDEX_EXPRESSION_RULE]),
 };
 
 const INTEGER_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::INT,
-    parse: |lexer, _| {
-        let token = lexer.next().unwrap();
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::INT {
+                return Ok(None);
+            }
 
-        let value = match token.literal.parse::<i64>() {
-            Ok(value) => value,
-            Err(_) => return Err(Error::IllegalToken(token)),
-        };
+            let token = lexer.next().unwrap();
 
-        Ok(Expression::INT(IntExpression { token, value }))
+            let value = match token.literal.parse::<i64>() {
+                Ok(value) => value,
+                Err(_) => return Err(Error::IllegalToken(token)),
+            };
+
+            return Ok(Some(Expression::INT(IntExpression { token, value })));
+        }
+
+        Ok(None)
     },
     dependents: None,
 };
 
 const STRING_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::STRING,
-    parse: |lexer, _| {
-        let token = lexer.next().unwrap();
-        let value = token.literal[1..token.literal.len() - 1].into();
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::STRING {
+                return Ok(None);
+            }
 
-        Ok(Expression::STRING(StringExpression { token, value }))
+            let token = lexer.next().unwrap();
+            let value = token.literal[1..token.literal.len() - 1].into();
+
+            return Ok(Some(Expression::STRING(StringExpression { token, value })));
+        }
+
+        Ok(None)
     },
     dependents: None,
 };
 
 const BOOLEAN_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::TRUE || token.kind == TokenKind::FALSE,
-    parse: |lexer, _| {
-        let token = lexer.next().unwrap();
-        let value = token.kind == TokenKind::TRUE;
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::TRUE && token.kind != TokenKind::FALSE {
+                return Ok(None);
+            }
 
-        Ok(Expression::BOOLEAN(BooleanExpression { token, value }))
+            let token = lexer.next().unwrap();
+            let value = token.kind == TokenKind::TRUE;
+
+            return Ok(Some(Expression::BOOLEAN(BooleanExpression {
+                token,
+                value,
+            })));
+        }
+
+        Ok(None)
     },
     dependents: None,
 };
 
 const ARRAY_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::LBRACKET,
-    parse: |lexer, _| {
-        let token = match lexer.next() {
-            Some(token) if token.kind == TokenKind::LBRACKET => token,
-            option => return Err(Error::MissingOpeningBracket(option)),
-        };
-
-        let mut elements = Vec::new();
-
-        while let Some(token) = lexer.peek() {
-            if token.kind == TokenKind::RBRACKET {
-                break;
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::LBRACKET {
+                return Ok(None);
             }
 
-            let expression = ExpressionParser::parse(lexer, &Precedence::LOWEST)?;
-
-            elements.push(expression);
-
-            if let Some(token) = lexer.peek() {
-                if token.kind == TokenKind::COMMA {
-                    lexer.next();
-                }
-            }
-        }
-
-        match lexer.next() {
-            Some(token) if token.kind == TokenKind::RBRACKET => token,
-            option => return Err(Error::MissingClosingBracket(option)),
-        };
-
-        Ok(Expression::ARRAY(ArrayExpression { token, elements }))
-    },
-    dependents: Some(&[INDEX_EXPRESSION_RULE]),
-};
-
-const PREFIX_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::MINUS || token.kind == TokenKind::BANG,
-    parse: |lexer, _| {
-        let operator = lexer.next().unwrap();
-
-        let right = Box::new(ExpressionParser::parse(lexer, &Precedence::PREFIX)?);
-
-        Ok(Expression::PREFIX(PrefixExpression { operator, right }))
-    },
-    dependents: None,
-};
-
-const IF_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::IF,
-    parse: |lexer, _| {
-        let token = lexer.next().unwrap();
-
-        let condition = Box::new(ExpressionParser::parse(lexer, &Precedence::LOWEST)?);
-
-        let consequence = match StatementParser::parse(lexer)? {
-            Statement::Block(expression) => expression,
-            Statement::Let(expression) => {
-                return Err(Error::MissingBlockStatement(Some(expression.token)))
-            }
-            Statement::Return(expression) => {
-                return Err(Error::MissingBlockStatement(Some(expression.token)))
-            }
-            Statement::Expression(expression) => {
-                return Err(Error::MissingBlockStatement(Some(expression.token)))
-            }
-        };
-
-        let alternative = match lexer.peek() {
-            Some(token) if token.kind == TokenKind::ELSE => {
-                lexer.next().unwrap();
-
-                match StatementParser::parse(lexer)? {
-                    Statement::Block(expression) => Some(expression),
-                    Statement::Let(expression) => {
-                        return Err(Error::MissingBlockStatement(Some(expression.token)))
-                    }
-                    Statement::Return(expression) => {
-                        return Err(Error::MissingBlockStatement(Some(expression.token)))
-                    }
-                    Statement::Expression(expression) => {
-                        return Err(Error::MissingBlockStatement(Some(expression.token)))
-                    }
-                }
-            }
-            _ => None,
-        };
-
-        Ok(Expression::IF(IfExpression {
-            token,
-            condition,
-            consequence,
-            alternative,
-        }))
-    },
-    dependents: None,
-};
-
-const FUNCTION_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::FUNCTION,
-    parse: |lexer, _| {
-        let token = lexer.next().unwrap();
-
-        let parameters = {
-            match lexer.next() {
-                Some(token) if token.kind == TokenKind::LPAREN => token,
-                option => return Err(Error::MissingOpeningParenthesis(option)),
+            let token = match lexer.next() {
+                Some(token) if token.kind == TokenKind::LBRACKET => token,
+                option => return Err(Error::MissingOpeningBracket(option)),
             };
 
-            let mut parameters = Vec::new();
+            let mut elements = Vec::new();
 
             while let Some(token) = lexer.peek() {
-                if token.kind == TokenKind::RPAREN {
-                    break;
-                }
-
-                match lexer.next() {
-                    Some(token) if token.kind == TokenKind::IDENT => {
-                        let value = token.literal.clone();
-
-                        parameters.push(IdentExpression { token, value });
-                    }
-                    option => return Err(Error::MissingIdentifier(option)),
-                }
-
-                if let Some(token) = lexer.peek() {
-                    if token.kind == TokenKind::COMMA {
-                        lexer.next();
-                    }
-                }
-            }
-
-            match lexer.next() {
-                Some(token) if token.kind == TokenKind::RPAREN => token,
-                option => return Err(Error::MissingClosingParenthesis(option)),
-            };
-
-            parameters
-        };
-
-        let body = match StatementParser::parse(lexer)? {
-            Statement::Block(expression) => expression,
-            Statement::Let(expression) => {
-                return Err(Error::MissingBlockStatement(Some(expression.token)))
-            }
-            Statement::Return(expression) => {
-                return Err(Error::MissingBlockStatement(Some(expression.token)))
-            }
-            Statement::Expression(expression) => {
-                return Err(Error::MissingBlockStatement(Some(expression.token)))
-            }
-        };
-
-        Ok(Expression::FUNCTION(FunctionExpression {
-            token,
-            parameters,
-            body,
-        }))
-    },
-    dependents: Some(&[CALL_EXPRESSION_RULE]),
-};
-
-const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::LPAREN,
-    parse: |lexer, previous| {
-        let token = match &previous {
-            Some(Expression::IDENT(ident)) => ident.token.clone(),
-            Some(Expression::FUNCTION(func)) => func.token.clone(),
-            _ => unreachable!(),
-        };
-
-        let function = match &previous {
-            Some(Expression::IDENT(ident)) => Box::new(Expression::IDENT(ident.clone())),
-            Some(Expression::FUNCTION(func)) => Box::new(Expression::FUNCTION(func.clone())),
-            _ => unreachable!(),
-        };
-
-        let arguments = {
-            match lexer.next() {
-                Some(token) if token.kind == TokenKind::LPAREN => token,
-                option => return Err(Error::MissingOpeningParenthesis(option)),
-            };
-
-            let mut arguments = Vec::new();
-
-            while let Some(token) = lexer.peek() {
-                if token.kind == TokenKind::RPAREN {
+                if token.kind == TokenKind::RBRACKET {
                     break;
                 }
 
                 let expression = ExpressionParser::parse(lexer, &Precedence::LOWEST)?;
 
-                arguments.push(expression);
+                elements.push(expression);
 
                 if let Some(token) = lexer.peek() {
                     if token.kind == TokenKind::COMMA {
@@ -360,50 +227,270 @@ const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
             }
 
             match lexer.next() {
-                Some(token) if token.kind == TokenKind::RPAREN => token,
-                option => return Err(Error::MissingClosingParenthesis(option)),
+                Some(token) if token.kind == TokenKind::RBRACKET => token,
+                option => return Err(Error::MissingClosingBracket(option)),
             };
 
-            arguments
-        };
+            return Ok(Some(Expression::ARRAY(ArrayExpression { token, elements })));
+        }
 
-        Ok(Expression::CALL(CallExpression {
-            token,
-            function,
-            arguments,
-        }))
+        Ok(None)
+    },
+    dependents: Some(&[INDEX_EXPRESSION_RULE]),
+};
+
+const PREFIX_EXPRESSION_RULE: Rule<Expression> = Rule {
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::MINUS && token.kind != TokenKind::BANG {
+                return Ok(None);
+            }
+
+            let operator = lexer.next().unwrap();
+
+            let right = Box::new(ExpressionParser::parse(lexer, &Precedence::PREFIX)?);
+
+            return Ok(Some(Expression::PREFIX(PrefixExpression {
+                operator,
+                right,
+            })));
+        }
+
+        Ok(None)
+    },
+    dependents: None,
+};
+
+const IF_EXPRESSION_RULE: Rule<Expression> = Rule {
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::IF {
+                return Ok(None);
+            }
+
+            let token = lexer.next().unwrap();
+
+            let condition = Box::new(ExpressionParser::parse(lexer, &Precedence::LOWEST)?);
+
+            let consequence = match StatementParser::parse(lexer)? {
+                Statement::Block(expression) => expression,
+                Statement::Let(expression) => {
+                    return Err(Error::MissingBlockStatement(Some(expression.token)))
+                }
+                Statement::Return(expression) => {
+                    return Err(Error::MissingBlockStatement(Some(expression.token)))
+                }
+                Statement::Expression(expression) => {
+                    return Err(Error::MissingBlockStatement(Some(expression.token)))
+                }
+            };
+
+            let alternative = match lexer.peek() {
+                Some(token) if token.kind == TokenKind::ELSE => {
+                    lexer.next().unwrap();
+
+                    match StatementParser::parse(lexer)? {
+                        Statement::Block(expression) => Some(expression),
+                        Statement::Let(expression) => {
+                            return Err(Error::MissingBlockStatement(Some(expression.token)))
+                        }
+                        Statement::Return(expression) => {
+                            return Err(Error::MissingBlockStatement(Some(expression.token)))
+                        }
+                        Statement::Expression(expression) => {
+                            return Err(Error::MissingBlockStatement(Some(expression.token)))
+                        }
+                    }
+                }
+                _ => None,
+            };
+
+            return Ok(Some(Expression::IF(IfExpression {
+                token,
+                condition,
+                consequence,
+                alternative,
+            })));
+        }
+
+        Ok(None)
+    },
+    dependents: None,
+};
+
+const FUNCTION_EXPRESSION_RULE: Rule<Expression> = Rule {
+    consume: |lexer, _| {
+        if let Some(token) = lexer.peek() {
+            if token.kind != TokenKind::FUNCTION {
+                return Ok(None);
+            }
+
+            let token = lexer.next().unwrap();
+
+            let parameters = {
+                match lexer.next() {
+                    Some(token) if token.kind == TokenKind::LPAREN => token,
+                    option => return Err(Error::MissingOpeningParenthesis(option)),
+                };
+
+                let mut parameters = Vec::new();
+
+                while let Some(token) = lexer.peek() {
+                    if token.kind == TokenKind::RPAREN {
+                        break;
+                    }
+
+                    match lexer.next() {
+                        Some(token) if token.kind == TokenKind::IDENT => {
+                            let value = token.literal.clone();
+
+                            parameters.push(IdentExpression { token, value });
+                        }
+                        option => return Err(Error::MissingIdentifier(option)),
+                    }
+
+                    if let Some(token) = lexer.peek() {
+                        if token.kind == TokenKind::COMMA {
+                            lexer.next();
+                        }
+                    }
+                }
+
+                match lexer.next() {
+                    Some(token) if token.kind == TokenKind::RPAREN => token,
+                    option => return Err(Error::MissingClosingParenthesis(option)),
+                };
+
+                parameters
+            };
+
+            let body = match StatementParser::parse(lexer)? {
+                Statement::Block(expression) => expression,
+                Statement::Let(expression) => {
+                    return Err(Error::MissingBlockStatement(Some(expression.token)))
+                }
+                Statement::Return(expression) => {
+                    return Err(Error::MissingBlockStatement(Some(expression.token)))
+                }
+                Statement::Expression(expression) => {
+                    return Err(Error::MissingBlockStatement(Some(expression.token)))
+                }
+            };
+
+            return Ok(Some(Expression::FUNCTION(FunctionExpression {
+                token,
+                parameters,
+                body,
+            })));
+        }
+
+        Ok(None)
+    },
+    dependents: Some(&[CALL_EXPRESSION_RULE]),
+};
+
+const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
+    consume: |lexer, previous| {
+        if let Some(token) = lexer.peek() {
+            if previous.is_none() || token.kind != TokenKind::LPAREN {
+                return Ok(None);
+            }
+
+            let token = match &previous {
+                Some(Expression::IDENT(ident)) => ident.token.clone(),
+                Some(Expression::FUNCTION(func)) => func.token.clone(),
+                _ => unreachable!(),
+            };
+
+            let function = match &previous {
+                Some(Expression::IDENT(ident)) => Box::new(Expression::IDENT(ident.clone())),
+                Some(Expression::FUNCTION(func)) => Box::new(Expression::FUNCTION(func.clone())),
+                _ => unreachable!(),
+            };
+
+            let arguments = {
+                match lexer.next() {
+                    Some(token) if token.kind == TokenKind::LPAREN => token,
+                    option => return Err(Error::MissingOpeningParenthesis(option)),
+                };
+
+                let mut arguments = Vec::new();
+
+                while let Some(token) = lexer.peek() {
+                    if token.kind == TokenKind::RPAREN {
+                        break;
+                    }
+
+                    let expression = ExpressionParser::parse(lexer, &Precedence::LOWEST)?;
+
+                    arguments.push(expression);
+
+                    if let Some(token) = lexer.peek() {
+                        if token.kind == TokenKind::COMMA {
+                            lexer.next();
+                        }
+                    }
+                }
+
+                match lexer.next() {
+                    Some(token) if token.kind == TokenKind::RPAREN => token,
+                    option => return Err(Error::MissingClosingParenthesis(option)),
+                };
+
+                arguments
+            };
+
+            return Ok(Some(Expression::CALL(CallExpression {
+                token,
+                function,
+                arguments,
+            })));
+        }
+
+        Ok(None)
     },
     dependents: None,
 };
 
 const INDEX_EXPRESSION_RULE: Rule<Expression> = Rule {
-    accept: |token| token.kind == TokenKind::LBRACKET,
-    parse: |lexer, previous| {
-        let token = match previous {
-            Some(Expression::IDENT(ident)) => ident.token.clone(),
-            Some(Expression::ARRAY(array)) => array.token.clone(),
-            _ => unreachable!(),
-        };
+    consume: |lexer, previous| {
+        if let Some(token) = lexer.peek() {
+            if previous.is_none() || token.kind != TokenKind::LBRACKET {
+                return Ok(None);
+            }
 
-        let left = match previous {
-            Some(Expression::IDENT(ident)) => Box::new(Expression::IDENT(ident.clone())),
-            Some(Expression::ARRAY(array)) => Box::new(Expression::ARRAY(array.clone())),
-            _ => unreachable!(),
-        };
+            let token = match previous {
+                Some(Expression::IDENT(ident)) => ident.token.clone(),
+                Some(Expression::ARRAY(array)) => array.token.clone(),
+                _ => unreachable!(),
+            };
 
-        match lexer.next() {
-            Some(token) if token.kind == TokenKind::LBRACKET => token,
-            option => return Err(Error::MissingOpeningBracket(option)),
-        };
+            let left = match previous {
+                Some(Expression::IDENT(ident)) => Box::new(Expression::IDENT(ident.clone())),
+                Some(Expression::ARRAY(array)) => Box::new(Expression::ARRAY(array.clone())),
+                _ => unreachable!(),
+            };
 
-        let index = Box::new(ExpressionParser::parse(lexer, &Precedence::LOWEST)?);
+            match lexer.next() {
+                Some(token) if token.kind == TokenKind::LBRACKET => token,
+                option => return Err(Error::MissingOpeningBracket(option)),
+            };
 
-        match lexer.next() {
-            Some(token) if token.kind == TokenKind::RBRACKET => token,
-            option => return Err(Error::MissingClosingBracket(option)),
-        };
+            let index = Box::new(ExpressionParser::parse(lexer, &Precedence::LOWEST)?);
 
-        Ok(Expression::INDEX(IndexExpression { token, left, index }))
+            match lexer.next() {
+                Some(token) if token.kind == TokenKind::RBRACKET => token,
+                option => return Err(Error::MissingClosingBracket(option)),
+            };
+
+            return Ok(Some(Expression::INDEX(IndexExpression {
+                token,
+                left,
+                index,
+            })));
+        }
+
+        Ok(None)
     },
     dependents: None,
 };

--- a/src/parser/rule.rs
+++ b/src/parser/rule.rs
@@ -1,32 +1,28 @@
-use crate::{parser::error::Result, Lexer, Token};
+use crate::{parser::error::Result, Lexer};
 
 #[derive(Debug)]
 pub struct Rule<'a, T> {
-    pub accept: fn(token: &Token) -> bool,
-    pub parse: fn(lexer: &mut Lexer, previous: &Option<T>) -> Result<T>,
+    pub consume: fn(lexer: &mut Lexer, previous: Option<&T>) -> Result<Option<T>>,
     pub dependents: Option<&'a [Rule<'a, T>]>,
 }
 
 impl<'a, T> Rule<'a, T> {
-    pub fn parse(previous: &Option<T>, rule: &Rule<T>, lexer: &mut Lexer) -> Result<Option<T>> {
-        if let Some(token) = lexer.peek() {
-            if (rule.accept)(token) {
-                let statement = Some((rule.parse)(lexer, previous)?);
-
-                if let Some(dependents) = &rule.dependents {
+    pub fn parse(self: &Rule<'a, T>, lexer: &mut Lexer, previous: Option<&T>) -> Result<Option<T>> {
+        match (self.consume)(lexer, previous)? {
+            Some(rule_output) => {
+                if let Some(dependents) = self.dependents {
                     for dependent in dependents.iter() {
-                        if let Some(dependent_statement) =
-                            Rule::parse(&statement, dependent, lexer)?
+                        if let Some(dependent_output) =
+                            (dependent.consume)(lexer, Some(&rule_output))?
                         {
-                            return Ok(Some(dependent_statement));
+                            return Ok(Some(dependent_output));
                         }
                     }
                 }
 
-                return Ok(statement);
+                Ok(Some(rule_output))
             }
+            None => Ok(None),
         }
-
-        Ok(None)
     }
 }


### PR DESCRIPTION



## 🎯 Changes

- refactored the `Rule` struct to use a `consume` function instead of separate `accept` and `parse` functions
- updated `Rule::parse` method to handle rule consumption and dependent rules more efficiently
- modified all statement and expression rules to use the new `consume` function pattern
- improved lexer peeking and token consumption in various parser rules
- updated `ExpressionParser` and `StatementParser` to use the new rule parsing approach
- removed unnecessary token checks and simplified rule logic across multiple files
