### PR TITLE
feat(lexer): add support for colon token

### DIFF
--- a/src/ast/token.rs
+++ b/src/ast/token.rs
@@ -21,6 +21,7 @@ pub enum TokenKind {
 
     // delimiters
     COMMA,
+    COLON,
     SEMICOLON,
 
     // brackets

--- a/src/lexer.rs
+++ b/src/lexer.rs
@@ -231,6 +231,13 @@ impl Lexer<'_> {
             return self.cursor.capture(TokenKind::COMMA);
         }
 
+        // capture colon_delimiter
+        if let Some(':') = self.cursor.first() {
+            self.cursor.advance();
+
+            return self.cursor.capture(TokenKind::COLON);
+        }
+
         // capture semicolon_delimiter
         if let Some(';') = self.cursor.first() {
             self.cursor.advance();
@@ -496,6 +503,15 @@ mod tests {
         let token = lexer.next().unwrap();
 
         assert_eq!(token.kind, TokenKind::COMMA);
+    }
+
+    #[test]
+    fn capture_colon_delimiter() {
+        let mut lexer = Lexer::new(":");
+
+        let token = lexer.next().unwrap();
+
+        assert_eq!(token.kind, TokenKind::COLON);
     }
 
     #[test]


### PR DESCRIPTION
## 🎯 Changes

- added `COLON` variant to `TokenKind` enum in `token.rs`
- implemented colon delimiter capture in `lexer.rs`
- added unit test for colon delimiter capture

This change enables the lexer to recognize and tokenize colon characters as delimiters, enhancing the parser's capability to handle more complex syntax structures.