### PR TITLE
refactor(lexer): implement multi-token peeking with VecDeque

### DIFF
--- a/src/parser/expression.rs
+++ b/src/parser/expression.rs
@@ -54,7 +54,7 @@ impl ExpressionParser {
     pub fn parse(lexer: &mut Lexer, precedence: &Precedence) -> Result<Expression> {
         let mut left = ExpressionParser::parse_left(lexer)?;
 
-        while let Some(token) = lexer.peek() {
+        while let Some(token) = lexer.peek(0) {
             if precedence >= &Precedence::from(&token.kind) {
                 break;
             }
@@ -92,7 +92,7 @@ const EXPRESSION_RULES: [Rule<Expression>; 9] = [
 
 const GROUPING_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::LPAREN {
                 return Ok(None);
             }
@@ -119,7 +119,7 @@ const GROUPING_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const IDENTIFIER_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::IDENT {
                 return Ok(None);
             }
@@ -137,7 +137,7 @@ const IDENTIFIER_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const INTEGER_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::INT {
                 return Ok(None);
             }
@@ -159,7 +159,7 @@ const INTEGER_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const STRING_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::STRING {
                 return Ok(None);
             }
@@ -177,7 +177,7 @@ const STRING_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const BOOLEAN_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::TRUE && token.kind != TokenKind::FALSE {
                 return Ok(None);
             }
@@ -198,7 +198,7 @@ const BOOLEAN_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const ARRAY_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::LBRACKET {
                 return Ok(None);
             }
@@ -210,7 +210,7 @@ const ARRAY_EXPRESSION_RULE: Rule<Expression> = Rule {
 
             let mut elements = Vec::new();
 
-            while let Some(token) = lexer.peek() {
+            while let Some(token) = lexer.peek(0) {
                 if token.kind == TokenKind::RBRACKET {
                     break;
                 }
@@ -219,7 +219,7 @@ const ARRAY_EXPRESSION_RULE: Rule<Expression> = Rule {
 
                 elements.push(expression);
 
-                if let Some(token) = lexer.peek() {
+                if let Some(token) = lexer.peek(0) {
                     if token.kind == TokenKind::COMMA {
                         lexer.next();
                     }
@@ -241,7 +241,7 @@ const ARRAY_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const PREFIX_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::MINUS && token.kind != TokenKind::BANG {
                 return Ok(None);
             }
@@ -263,7 +263,7 @@ const PREFIX_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const IF_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::IF {
                 return Ok(None);
             }
@@ -285,7 +285,7 @@ const IF_EXPRESSION_RULE: Rule<Expression> = Rule {
                 }
             };
 
-            let alternative = match lexer.peek() {
+            let alternative = match lexer.peek(0) {
                 Some(token) if token.kind == TokenKind::ELSE => {
                     lexer.next().unwrap();
 
@@ -320,7 +320,7 @@ const IF_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const FUNCTION_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::FUNCTION {
                 return Ok(None);
             }
@@ -335,7 +335,7 @@ const FUNCTION_EXPRESSION_RULE: Rule<Expression> = Rule {
 
                 let mut parameters = Vec::new();
 
-                while let Some(token) = lexer.peek() {
+                while let Some(token) = lexer.peek(0) {
                     if token.kind == TokenKind::RPAREN {
                         break;
                     }
@@ -349,7 +349,7 @@ const FUNCTION_EXPRESSION_RULE: Rule<Expression> = Rule {
                         option => return Err(Error::MissingIdentifier(option)),
                     }
 
-                    if let Some(token) = lexer.peek() {
+                    if let Some(token) = lexer.peek(0) {
                         if token.kind == TokenKind::COMMA {
                             lexer.next();
                         }
@@ -391,7 +391,7 @@ const FUNCTION_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, previous| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if previous.is_none() || token.kind != TokenKind::LPAREN {
                 return Ok(None);
             }
@@ -416,7 +416,7 @@ const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
 
                 let mut arguments = Vec::new();
 
-                while let Some(token) = lexer.peek() {
+                while let Some(token) = lexer.peek(0) {
                     if token.kind == TokenKind::RPAREN {
                         break;
                     }
@@ -425,7 +425,7 @@ const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
 
                     arguments.push(expression);
 
-                    if let Some(token) = lexer.peek() {
+                    if let Some(token) = lexer.peek(0) {
                         if token.kind == TokenKind::COMMA {
                             lexer.next();
                         }
@@ -454,7 +454,7 @@ const CALL_EXPRESSION_RULE: Rule<Expression> = Rule {
 
 const INDEX_EXPRESSION_RULE: Rule<Expression> = Rule {
     consume: |lexer, previous| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if previous.is_none() || token.kind != TokenKind::LBRACKET {
                 return Ok(None);
             }

--- a/src/parser/mod.rs
+++ b/src/parser/mod.rs
@@ -22,7 +22,7 @@ impl<'a> Parser<'a> {
     pub fn parse(&mut self) -> Result<Program> {
         let mut program = Program::new();
 
-        while let Some(token) = self.lexer.peek() {
+        while let Some(token) = self.lexer.peek(0) {
             if token.kind == TokenKind::EOF {
                 break;
             }

--- a/src/parser/statement.rs
+++ b/src/parser/statement.rs
@@ -36,7 +36,7 @@ const STATEMENT_RULES: [Rule<Statement>; 4] = [
 
 const BLOCK_STATEMENT_RULE: Rule<Statement> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::LBRACE {
                 return Ok(None);
             }
@@ -48,7 +48,7 @@ const BLOCK_STATEMENT_RULE: Rule<Statement> = Rule {
 
             let mut statements = Vec::new();
 
-            while let Some(token) = lexer.peek() {
+            while let Some(token) = lexer.peek(0) {
                 if token.kind == TokenKind::RBRACE {
                     break;
                 }
@@ -71,7 +71,7 @@ const BLOCK_STATEMENT_RULE: Rule<Statement> = Rule {
 
 const LET_STATEMENT_RULE: Rule<Statement> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::LET {
                 return Ok(None);
             }
@@ -113,7 +113,7 @@ const LET_STATEMENT_RULE: Rule<Statement> = Rule {
 
 const RETURN_STATEMENT_RULE: Rule<Statement> = Rule {
     consume: |lexer, _| {
-        if let Some(token) = lexer.peek() {
+        if let Some(token) = lexer.peek(0) {
             if token.kind != TokenKind::RETURN {
                 return Ok(None);
             }
@@ -143,7 +143,7 @@ const RETURN_STATEMENT_RULE: Rule<Statement> = Rule {
 
 const EXPRESSION_STATEMENT_RULE: Rule<Statement> = Rule {
     consume: |lexer, _| {
-        let token = lexer.peek().unwrap().clone();
+        let token = lexer.peek(0).unwrap().clone();
         let expression = ExpressionParser::parse(lexer, &Precedence::LOWEST)?;
 
         match lexer.next() {


### PR DESCRIPTION
## 🎯 Changes

- replaced `peeked: Option<Token>` with `peeked: VecDeque<Token>` in the `Lexer` struct
- updated `next()` method to pop from the front of the `peeked` queue and capture new tokens as needed
- implemented a new `peek(i: usize)` method to allow peeking multiple tokens ahead
- modified `capture_*` test functions to use `peek(0)` instead of `next()`
- updated all occurrences of `lexer.peek()` to `lexer.peek(0)` throughout the parser
- removed the `Iterator` implementation for `Lexer`

These changes improve the lexer's flexibility by allowing it to look ahead multiple tokens, which can be useful for more complex parsing scenarios.