### PR TITLE
feat: implement hash literals

### DIFF
--- a/src/ast/expression.rs
+++ b/src/ast/expression.rs
@@ -163,6 +163,33 @@ impl Display for FunctionExpression {
     }
 }
 
+pub type HashPair = (Box<Expression>, Box<Expression>);
+
+#[derive(Debug, PartialEq, Clone)]
+pub struct HashExpression {
+    pub token: Token,
+    pub pairs: Vec<HashPair>,
+}
+
+impl Display for HashExpression {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut output = String::new();
+        let mut pairs = String::new();
+
+        for (i, (key, value)) in self.pairs.iter().enumerate() {
+            pairs.push_str(&format!(" {}: {}", key, value));
+
+            if i < self.pairs.len() - 1 {
+                pairs.push_str(", ");
+            }
+        }
+
+        output.push_str(&format!("{{{}}}", pairs));
+
+        write!(f, "{}", output)
+    }
+}
+
 #[derive(Debug, PartialEq, Clone)]
 pub struct CallExpression {
     pub token: Token,
@@ -230,6 +257,7 @@ pub enum Expression {
     Index(IndexExpression),
     If(IfExpression),
     Function(FunctionExpression),
+    Hash(HashExpression),
     Call(CallExpression),
     Prefix(PrefixExpression),
     Infix(InfixExpression),
@@ -247,6 +275,7 @@ impl Display for Expression {
             Expression::Index(expression) => write!(f, "{}", expression),
             Expression::If(expression) => write!(f, "{}", expression),
             Expression::Function(expression) => write!(f, "{}", expression),
+            Expression::Hash(expression) => write!(f, "{}", expression),
             Expression::Call(expression) => write!(f, "{}", expression),
             Expression::Prefix(expression) => write!(f, "{}", expression),
             Expression::Infix(expression) => write!(f, "{}", expression),

--- a/src/evaluator/datatype.rs
+++ b/src/evaluator/datatype.rs
@@ -1,7 +1,25 @@
+use std::collections::HashMap;
 use std::{cell::RefCell, fmt::Display, rc::Rc};
 
 use crate::builtins::error::Result;
 use crate::{BlockExpression, Environment, IdentExpression};
+
+#[derive(Debug, PartialEq, Eq, Hash, Clone)]
+pub enum HashKey {
+    String(Box<str>),
+    Int(i64),
+    Boolean(bool),
+}
+
+impl Display for HashKey {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            HashKey::String(value) => write!(f, "{}", value),
+            HashKey::Int(value) => write!(f, "{}", value),
+            HashKey::Boolean(value) => write!(f, "{}", value),
+        }
+    }
+}
 
 #[derive(Debug, PartialEq, Clone)]
 pub enum DataType {
@@ -15,6 +33,9 @@ pub enum DataType {
         parameters: Vec<IdentExpression>,
         body: BlockExpression,
         env: Rc<RefCell<Environment>>,
+    },
+    HASH {
+        pairs: HashMap<HashKey, DataType>,
     },
     BUILTIN {
         func: fn(Vec<DataType>) -> Result<DataType>,
@@ -41,6 +62,23 @@ impl Display for DataType {
             DataType::RETURN(value) => write!(f, "{}", value),
             DataType::IDENT(value) => write!(f, "{}", value),
             DataType::FUNCTION { .. } => write!(f, ""),
+            DataType::HASH { pairs: map } => {
+                let mut output = String::new();
+
+                let mut pairs = String::new();
+
+                for (i, (key, value)) in map.iter().enumerate() {
+                    pairs.push_str(&format!(" {}: {}", key, value));
+
+                    if i < pairs.len() - 1 {
+                        pairs.push_str(", ");
+                    }
+                }
+
+                output.push_str(&format!("{{{}}}", pairs));
+
+                write!(f, "{}", output)
+            }
             DataType::BUILTIN { .. } => write!(f, ""),
             DataType::UNDEFINED => write!(f, ""),
             DataType::NULL => write!(f, "null"),

--- a/src/evaluator/error.rs
+++ b/src/evaluator/error.rs
@@ -5,6 +5,7 @@ use super::datatype::DataType;
 
 #[derive(Debug, thiserror::Error)]
 pub enum Error {
+    IllegalType(Token),
     TypeMismatch(DataType, Token, DataType),
     IndexTypeMismatch(DataType, Token),
     UnknownOperator(Token),
@@ -15,6 +16,11 @@ pub enum Error {
 impl Display for Error {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         match self {
+            Error::IllegalType(token) => write!(
+                f,
+                "illegal type {:?} at {}:{}",
+                token.literal, token.line, token.column
+            ),
             Error::TypeMismatch(left, token, right) => write!(
                 f,
                 "type mismatch {:?} {} {:?} at {}:{}",
@@ -23,7 +29,7 @@ impl Display for Error {
             Error::IndexTypeMismatch(value, token) => {
                 write!(
                     f,
-                    "index type mismatch got={:?}, want=INT at {}:{}",
+                    "index type mismatch got={:?} want=INT at {}:{}",
                     value, token.line, token.column
                 )
             }

--- a/src/parser/error.rs
+++ b/src/parser/error.rs
@@ -14,6 +14,7 @@ pub enum Error {
     MissingLetKeyword(Option<Token>),
     MissingAssignmentOperator(Option<Token>),
     MissingReturnKeyword(Option<Token>),
+    MissingColon(Option<Token>),
     MissingSemicolon(Option<Token>),
     MissingIdentifier(Option<Token>),
     MissingBlockExpression(Option<Token>),
@@ -96,6 +97,14 @@ impl Display for Error {
                     token.literal, token.line, token.column
                 ),
                 None => write!(f, "expected return keyword, got EOF"),
+            },
+            Error::MissingColon(token) => match token {
+                Some(token) => write!(
+                    f,
+                    "expected colon, got {} at {}:{}",
+                    token.literal, token.line, token.column
+                ),
+                None => write!(f, "expected colon, got EOF"),
             },
             Error::MissingSemicolon(token) => match token {
                 Some(token) => write!(


### PR DESCRIPTION
## 🎯 Changes

- introduced `HashExpression` and `HashKey` types to represent hash literals
- implemented parsing for hash expressions in the parser
- added support for evaluating hash expressions in the evaluator
- implemented hash indexing functionality for string, integer, and boolean keys
- extended the `DataType` enum to include a `HASH` variant
- added error handling for illegal hash key types
- implemented display formatting for hash expressions
- updated existing tests and added new tests for hash expressions and indexing
- added support for nested hash and array expressions