### PR TITLE
refactor: implement trait-based IR interpreter with improved documentation

### DIFF
--- a/src/ir/function.rs
+++ b/src/ir/function.rs
@@ -5,6 +5,7 @@ use internment::Intern;
 use crate::ir::program::Label;
 use crate::runtime::environment::Environment;
 
+/// a function is a list of parameters, a body label, and an environment
 #[derive(Debug, Clone, PartialEq)]
 pub struct Function {
     pub parameters: Vec<Intern<std::string::String>>,


### PR DESCRIPTION
## 🎯 Changes

- Refactored IR interpreter to use a trait-based approach with the `Interpret` trait
- Restructured instruction and terminator types into proper structs with enum wrappers
- Added comprehensive documentation comments to functions, structs, and enums
- Refactored `Program` class to use a vector of optional blocks instead of a HashMap
- Added `merge` method to `Program` to combine programs with proper label offsetting
- Implemented `Transpile` trait for AST nodes to convert them to IR
- Improved block handling with clearer method names (`add`, `get`, `end`)
- Added ability to execute programs from specific entry points with `execute_from`
- Enhanced error handling and simplified control flow in interpreter
- Improved code organization with better separation of concerns